### PR TITLE
improvement(analysis): set post title as the sitetitle to track activities on Google Analytics

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,16 +1,12 @@
 import Head from 'next/head';
 import { ReactNode } from 'react';
-import { createSiteTitle } from '../lib/head';
 import Footer from './Footer';
 import Header from './Header';
 
 const Layout = ({ children, currentPath }: { children?: ReactNode; currentPath: string }) => {
-  const siteTitle = createSiteTitle(currentPath);
-
   return (
     <div className="flex flex-col font-sans mx-4 sm:mx-16 md:mx-56 h-screen">
       <Head>
-        <title>{siteTitle}</title>
         <meta name="description" content="Kaoru Muta's personal website" />
         <link rel="icon" href="/favicon.ico" />
       </Head>

--- a/lib/head.tsx
+++ b/lib/head.tsx
@@ -1,9 +1,0 @@
-import { AppConstants } from '../constants/AppConstants';
-
-export const createSiteTitle = (path: string) => {
-  if (path === AppConstants.HomePage.PATH) {
-    return AppConstants.HomePage.TITLE;
-  } else if (path.startsWith(AppConstants.BlogPage.PATH)) {
-    return AppConstants.BlogPage.TITLE;
-  }
-};

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -1,4 +1,5 @@
 import { InferGetStaticPropsType } from 'next';
+import Head from 'next/head';
 import Gallery from '../components/Gallery';
 import Title from '../components/Title';
 import { AppConstants } from '../constants/AppConstants';
@@ -15,10 +16,15 @@ export const getStaticProps = async () => {
 
 const Blog = ({ allSortedPostsByDate }: InferGetStaticPropsType<typeof getStaticProps>) => {
   return (
-    <section className="divide-y my-16">
-      <Title name={AppConstants.BlogPage.TITLE} />
-      <Gallery posts={allSortedPostsByDate} />
-    </section>
+    <>
+      <Head>
+        <title>{AppConstants.BlogPage.TITLE}</title>
+      </Head>
+      <section className="divide-y my-16">
+        <Title name={AppConstants.BlogPage.TITLE} />
+        <Gallery posts={allSortedPostsByDate} />
+      </section>
+    </>
   );
 };
 

--- a/pages/blog/posts/[id].tsx
+++ b/pages/blog/posts/[id].tsx
@@ -1,4 +1,5 @@
 import { InferGetStaticPropsType } from 'next';
+import Head from 'next/head';
 import Description from '../../../components/Description';
 import Share from '../../../components/Share';
 import Title from '../../../components/Title';
@@ -26,14 +27,19 @@ const Post = ({ post }: InferGetStaticPropsType<typeof getStaticProps>) => {
   const url = `${process.env.HOST}/blog/posts/${id}`;
 
   return (
-    <article className="my-16">
-      <Title name={title} />
-      <Description date={date} categories={categories} />
-      <hr className="mt-4"></hr>
-      <article className="py-4 max-w-none prose xl:prose-xl" dangerouslySetInnerHTML={{ __html: content }} />
-      <hr className="mb-4"></hr>
-      <Share url={url} title={title} />
-    </article>
+    <>
+      <Head>
+        <title>{title}</title>
+      </Head>
+      <article className="my-16">
+        <Title name={title} />
+        <Description date={date} categories={categories} />
+        <hr className="mt-4"></hr>
+        <article className="py-4 max-w-none prose xl:prose-xl" dangerouslySetInnerHTML={{ __html: content }} />
+        <hr className="mb-4"></hr>
+        <Share url={url} title={title} />
+      </article>
+    </>
   );
 };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,17 @@
 import type { NextPage } from 'next';
+import Head from 'next/head';
 import Profile from '../components/Profile';
+import { AppConstants } from '../constants/AppConstants';
 
 const Home: NextPage = () => {
-  return <Profile />;
+  return (
+    <>
+      <Head>
+        <title>{AppConstants.HomePage.TITLE}</title>
+      </Head>
+      <Profile />
+    </>
+  );
 };
 
 export default Home;


### PR DESCRIPTION
## Overview
Here is a PR about setting post title as the sitetitle.

## Changes in this PR
- Change the way to describe `Head`statements