### PR TITLE
feat(#53): remove prefix date from post uri

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -15,7 +15,7 @@ const loadAllPosts = (directoryPath: string): PostPropsType[] => {
       const postContents = fs.readFileSync(`${file.path}/${file.name}`, 'utf-8');
       const matterResult = matter(postContents);
       const { title, date, categories } = matterResult.data;
-      const postId = file.name.replace(/.md$/, '');
+      const postId = file.name.replace(/^[0-9]{8,}-|\.md$/, '');
       const displayedCategories = categories !== undefined || !categories.length ? categories.split(' ') : [];
       return {
         id: postId,


### PR DESCRIPTION
## Overview (Please describe the detail of PR)

PR for #53.
It's better to remove date prefix in file name for uri because date information is not necessary as uri perspective

## Changes in this PR

- Remove date from uri