### PR TITLE
fix: add missing redirect setting to go to latest post url

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,4 +8,15 @@ module.exports = {
     GOOGLE_ADSENSE_CLIENT_ID: 'ca-pub-8671682597497935',
     GOOGLE_ADSENSE_SLOT_ID: '1520904619',
   },
+  // NOTE: Googleのインデックスに `.md` 付きのURLが登録されているため、一時的にリダイレクトを設定
+  // See: https://vercel.com/docs/edge-network/redirects
+  async redirects() {
+    return [
+      {
+        "source": "/blog/posts/:slug.md",
+        "destination": "/blog/posts/:slug",
+        "permanent": true
+      }
+    ]
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mysite",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",


### PR DESCRIPTION
## Overview (Please describe the detail of PR)

Due to https://github.com/KaoruMuta/KaoruMuta.me/pull/56, `.md` is included in post URL.
I fixed this issue by https://github.com/KaoruMuta/KaoruMuta.me/pull/75, but Google continues to remain old URL index so temporally I added redirect setting not to visit 404 pages